### PR TITLE
shipping calculation depending on the product type.

### DIFF
--- a/shipping/flat_rate.php
+++ b/shipping/flat_rate.php
@@ -45,23 +45,23 @@ class flat_rate extends jigoshop_shipping_method {
 				if ($_product->exists() && $values['quantity']>0) :
 					
 					$item_shipping_price = ($this->cost + $this->get_fee( $this->fee, $_product->get_price() )) * $values['quantity'];
-					
-					$this->shipping_total = $this->shipping_total + $item_shipping_price;
+					if ($_product->is_type( 'simple' )) {
+						$this->shipping_total = $this->shipping_total + $item_shipping_price;
 
-					if ( $_product->is_shipping_taxable() && $this->tax_status=='taxable' ) :
-					
-						$rate = $_tax->get_shipping_tax_rate( $_product->data['tax_class'] );
+						if ( $_product->is_shipping_taxable() && $this->tax_status=='taxable' ) :
 						
-						if ($rate>0) :
-						
-							$tax_amount = $_tax->calc_shipping_tax( $item_shipping_price, $rate );
-						
-							$this->shipping_tax = $this->shipping_tax + $tax_amount;
+							$rate = $_tax->get_shipping_tax_rate( $_product->data['tax_class'] );
+							
+							if ($rate>0) :
+							
+								$tax_amount = $_tax->calc_shipping_tax( $item_shipping_price, $rate );
+							
+								$this->shipping_tax = $this->shipping_tax + $tax_amount;
+							
+							endif;
 						
 						endif;
-					
-					endif;
-					
+					}
 				endif;
 			endforeach; endif;
 		endif;			


### PR DESCRIPTION
We were having issues when having both virtual and simple products in the cart with flat rate enabled "per item". It was calculating the shipping cost of every item regardless of the type.

fix: product type is checked on every cart item for calculating shipping costs
