### PR TITLE
Dibs gateway

### DIFF
--- a/gateways/dibs.php
+++ b/gateways/dibs.php
@@ -262,14 +262,9 @@ class dibs extends jigoshop_payment_gateway {
 			$vars = 'transact='. $posted['transact'] . '&amount=' . $posted['amount'] . '&currency=' . $posted['currency'];
 			$md5 = MD5($key2 . MD5($key1 . $vars));
 			
-			error_log('Posted: '.print_r($posted,true));
-			error_log("Key1: $key1  Key2: $key2  Vars: $vars");
-			error_log("Check: $md5 ".$posted['authkey']);
-			
 			if($posted['authkey'] != $md5) {
 				error_log('MD5 check failed for Dibs callback with order_id:'.$posted['orderid']);
-				// For some reason this MD5 stuff wont work, so accept anyway.
-				// exit();
+				exit();
 			}
 			
 			$order = new jigoshop_order( (int) $posted['orderid'] );


### PR DESCRIPTION
Here is a complete Dibs gateway. It is not yet used in production, but has been tested quite a bit.

There is one thing left that I don't know how to solve properly. Dibs ignores anything in the query string when redirecting to the success url and cancel url. The thankyou page is very much based on there being GET variables, but dibs provides none.

Somehow I need a hook or other way of writing som code in the dibs gateway that properly extracts the data we need from the postback so the thankyou page can display the order information.

Any suggestions?
