### PR TITLE
added to fix PayPal error: 'The link you have used to enter the PayPal sy

### DIFF
--- a/gateways/paypal.php
+++ b/gateways/paypal.php
@@ -230,8 +230,7 @@ class paypal extends jigoshop_payment_gateway {
 				
 				$paypal_args['item_name_'.$item_loop] = $title;
 				$paypal_args['quantity_'.$item_loop] = $item['qty'];
-				$paypal_args['amount_'.$item_loop] = $_product->get_price_excluding_tax();
-				
+				$paypal_args['amount_'.$item_loop] = number_format($_product->get_price_excluding_tax(), 2); //Apparently, Paypal did not like "28.4525" as the amount. Changing that to "28.45" fixed the issue.				
 			endif;
 		endforeach; endif;
        


### PR DESCRIPTION
added to fix PayPal error: 'The link you have used to enter the PayPal system contains an incorrectly formatted item amount.' due to four digit decimal. Apparently, Paypal did not like "28.4525" as the amount. Changing that to "28.45" fixed the issue.
