### PR TITLE
delete duplicate name attribute of Terms page ID select-page

### DIFF
--- a/admin/jigoshop-admin-settings-options.php
+++ b/admin/jigoshop-admin-settings-options.php
@@ -282,7 +282,6 @@ $options_settings = apply_filters('jigoshop_options_settings', array(
 		'css' 		=> 'min-width:50px;',
 		'std' 		=> '',
 		'type' 		=> 'single_select_page',
-		'name' 		=> __('Large Image Height','jigoshop'),
 		'args'		=> 'show_option_none=' . __('None', 'jigoshop'),
 	),
 


### PR DESCRIPTION
Hey,

in line 285 the name of the terms page is overwritten in the Array. I deleted it.
Another Question: Shouldn't the Page renamed to "Terms page" instead of "Terms page ID"?
