### PR TITLE
Add filters to the redirect target page in all checkout related files. German laws require a additional summary of all entered data before the final checkout. 

### DIFF
--- a/classes/jigoshop_checkout.class.php
+++ b/classes/jigoshop_checkout.class.php
@@ -637,12 +637,13 @@ class jigoshop_checkout {
 						jigoshop_cart::empty_cart();
 						
 						// Redirect to success/confirmation/payment page
+						$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
 						if (is_ajax()) : 
 							ob_clean();
-							echo json_encode( array('redirect'	=> get_permalink(get_option('jigoshop_thanks_page_id'))) );
+							echo json_encode( array( 'redirect'	=> get_permalink( $checkout_redirect ) ) );
 							exit;
 						else :
-							wp_safe_redirect( get_permalink(get_option('jigoshop_thanks_page_id')) );
+							wp_safe_redirect( get_permalink( $checkout_redirect ) );
 							exit;
 						endif;
 						

--- a/gateways/bank_transfer.php
+++ b/gateways/bank_transfer.php
@@ -167,10 +167,10 @@ class jigoshop_bank_transfer extends jigoshop_payment_gateway {
 		$order = &new jigoshop_order( $order_id );
 		$order->update_status('on-hold', __('Awaiting Bank Transfer', 'jigoshop'));
 		jigoshop_cart::empty_cart();
-			
+		$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
 		return array(
 			'result' 	=> 'success',
-			'redirect'	=> add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink(get_option('jigoshop_thanks_page_id'))))
+			'redirect'	=> add_query_arg( 'key', $order->order_key, add_query_arg( 'order', $order_id, get_permalink( $checkout_redirect ) ) )
 		);
 		
 	}

--- a/gateways/cheque.php
+++ b/gateways/cheque.php
@@ -100,9 +100,10 @@ class jigoshop_cheque extends jigoshop_payment_gateway {
 		jigoshop_cart::empty_cart();
 			
 		// Return thankyou redirect
+		$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
 		return array(
 			'result' 	=> 'success',
-			'redirect'	=> add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink(get_option('jigoshop_thanks_page_id'))))
+			'redirect'	=> add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink( $checkout_redirect )))
 		);
 		
 	}

--- a/gateways/dibs.php
+++ b/gateways/dibs.php
@@ -135,6 +135,8 @@ class dibs extends jigoshop_payment_gateway {
 			'CHF' => '756', // Swiss Franc
 			'TRY' => '949', // Turkish Lire
 		);
+		// filter redirect page
+		$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
 		
 		$args =
 			array(
@@ -156,7 +158,7 @@ class dibs extends jigoshop_payment_gateway {
 				'callbackurl' => site_url('/jigoshop/dibscallback.php'),
 				
 				// TODO these urls will not work correctly since DIBS ignores the querystring
-				'accepturl' => add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink(get_option('jigoshop_thanks_page_id')))),
+				'accepturl' => add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink($checkout_redirect))),
 				'cancelurl' => $order->get_cancel_order_url(),
 				
 		);

--- a/gateways/paypal.php
+++ b/gateways/paypal.php
@@ -151,6 +151,9 @@ class paypal extends jigoshop_payment_gateway {
 			);
 		endif;		
 		
+		// filter redirect page
+		$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
+		
 		$paypal_args = array_merge(
 			array(
 				'cmd' 					=> '_cart',
@@ -160,7 +163,7 @@ class paypal extends jigoshop_payment_gateway {
 				'charset' 				=> 'UTF-8',
 				'rm' 					=> 2,
 				'upload' 				=> 1,
-				'return' 				=> add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink(get_option('jigoshop_thanks_page_id')))),
+				'return' 				=> add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink( $checkout_redirect ))),
 				'cancel_return'			=> $order->get_cancel_order_url(),
 				//'cancel_return'			=> home_url(),
 				

--- a/gateways/skrill.php
+++ b/gateways/skrill.php
@@ -112,14 +112,17 @@ class skrill extends jigoshop_payment_gateway {
 		$order_total = trim($order->order_total, 0);
 
 		if( substr($order_total, -1) == '.' ) $order_total = str_replace('.', '', $order_total);
-					
+		
+		// filter redirect page
+		$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
+		
 		$skrill_args = array(
 			'merchant_fields' => 'partner',
 			'partner' => '21890813',
 			'pay_to_email' => $this->email,
 			'recipient_description' => get_bloginfo('name'),
 			'transaction_id' => $order_id,
-			'return_url' => get_permalink(get_option('jigoshop_thanks_page_id')),
+			'return_url' => get_permalink( $checkout_redirect ),
 			'return_url_text' => 'Return to Merchant',
 			'new_window_redirect' => 0,
 			'rid' => 20521479,

--- a/shortcodes/pay.php
+++ b/shortcodes/pay.php
@@ -61,7 +61,9 @@ function jigoshop_pay() {
 
 					// No payment was required for order
 					$order->payment_complete();
-					wp_safe_redirect( get_permalink(get_option('jigoshop_thanks_page_id')) );
+					// filter redirect page
+					$checkout_redirect = apply_filters( 'jigoshop_get_checkout_redirect_page_id', get_option( 'jigoshop_thanks_page_id' ) );
+					wp_safe_redirect( get_permalink( $checkout_redirect ) );
 					exit;
 
 				endif;


### PR DESCRIPTION
Hi, I'm completing the jigoshop-de Extension using your plugin, as successor of user https://github.com/bueltge 

Because you redirect directly to the thank you page, after entering the payment and shipping data, I need to filter the redirection page id. 
I added a filter: jigoshop_get_checkout_redirect_page_id
I had to change all payment modules, which is noch really the best way, but I didn't want to change too much code. Perhaps you have a better Idea of solving this problem. 

TIA 

Julian
