### PR TITLE
Fixes Review Order when used with Roots Theme

### DIFF
--- a/jigoshop_templates.php
+++ b/jigoshop_templates.php
@@ -124,12 +124,15 @@ function jigoshop_get_template($template_name, $require_once = true) {
 //################################################################################
 
 function jigoshop_get_template_file_url($template_name, $ssl = false) {
-	if (file_exists( STYLESHEETPATH . '/' . JIGOSHOP_TEMPLATE_URL . $template_name ))
-		$return = get_bloginfo('template_url') . '/' . JIGOSHOP_TEMPLATE_URL . $template_name;
-	elseif (file_exists( STYLESHEETPATH . '/' . $template_name ))
-		$return = get_bloginfo('template_url') . '/' . $template_name;
-	else
+	if (file_exists( STYLESHEETPATH . '/' . JIGOSHOP_TEMPLATE_URL . $template_name )) :
+		$file_path = STYLESHEETPATH . '/' . JIGOSHOP_TEMPLATE_URL . $template_name;
+		$return = str_replace($_SERVER['DOCUMENT_ROOT'], '', $file_path);
+	elseif (file_exists( STYLESHEETPATH . '/' . $template_name )) :
+		$file_path = STYLESHEETPATH . '/' . $template_name;
+		$return = str_replace($_SERVER['DOCUMENT_ROOT'], '', $file_path);
+	else :
 		$return = jigoshop::plugin_url() . '/templates/' . $template_name;
+	endif;
 
 	if (get_option('jigoshop_force_ssl_checkout')=='yes' || is_ssl()) :
 		if ($ssl) $return = str_replace('http:', 'https:', $return);


### PR DESCRIPTION
the [Roots Theme](http://www.rootstheme.com/) sets `'template_url'` for `get_bloginfo()` to the empty string (which is done to enable the linking of `wp-content/themes/themeName/css` to `css/` and the like), which causes issues with `jigoshop_get_template_file_url()` in its current state.  This commit ensures that the same file which `file_exists()` checked for is returned, instead of relying on `get_bloginfo()` to produce the correct path.

Additionally, this commit exchanges the one-line `if` syntax for the colon `if`/`endif` syntax used elsewhere in jigoshop.
