### PR TITLE
Add redirect to cart after add to cart option

### DIFF
--- a/admin/jigoshop-admin-settings-options.php
+++ b/admin/jigoshop-admin-settings-options.php
@@ -184,7 +184,8 @@ $options_settings = apply_filters('jigoshop_options_settings', array(
 		'type' 		=> 'select',
 		'options' => array(
 			'no'  => __('No', 'jigoshop'),
-			'yes' => __('Yes', 'jigoshop')
+			'yes' => __('Yes', 'jigoshop'),
+      'cart' => __('Redirect to Cart', 'jigoshop'),
 		)
 	),
 	

--- a/jigoshop_actions.php
+++ b/jigoshop_actions.php
@@ -289,6 +289,12 @@ function jigoshop_add_to_cart_action($url = false)
     else if (get_option('jigoshop_directly_to_checkout', 'no') == 'yes' && jigoshop::error_count() == 0) {
         wp_safe_redirect(jigoshop_cart::get_checkout_url());
     }
+    // Redirect directly to cart if no error messages
+    else if (get_option('jigoshop_directly_to_checkout', 'cart') == 'cart'
+             && jigoshop::error_count() == 0
+    ) {
+        wp_safe_redirect(jigoshop_cart::get_cart_url());
+    }
     // Otherwise redirect to where they came
     else if (isset($_SERVER['HTTP_REFERER'])) {
         wp_safe_redirect($_SERVER['HTTP_REFERER']);


### PR DESCRIPTION
There might be better ways to manage this (i.e., change the api a bit so that it is presented as a question:  "Redirect after add to cart?" with 'no', 'cart', 'checkout', etc. as options), but this way at least won't affect anyone's existing stores.

Since the shopping cart widget doesn't allow you to update totals, and I'm in a bit of a rush, I figured the easiest route was to simply add a few lines of code.
