### PR TITLE
Remove "e.g. special notes for delivery"

### DIFF
--- a/classes/jigoshop_checkout.class.php
+++ b/classes/jigoshop_checkout.class.php
@@ -141,7 +141,7 @@ class jigoshop_checkout {
 		
 		endif;
 		
-		$this->checkout_form_field( array( 'type' => 'textarea', 'class' => array('notes'),  'name' => 'order_comments', 'label' => __('Order Notes', 'jigoshop'), 'placeholder' => __('Notes about your order, e.g. special notes for delivery.', 'jigoshop') ) );
+		$this->checkout_form_field( array( 'type' => 'textarea', 'class' => array('notes'),  'name' => 'order_comments', 'label' => __('Order Notes', 'jigoshop'), 'placeholder' => __('Notes about your order.', 'jigoshop') ) );
 		
 	}
 


### PR DESCRIPTION
This Order Notes textarea appears whether or not Shipping is enabled, so it shouldn't be specific to Delivery.
