### PR TITLE
fixed bug, when no JavaScript, and errors in checkout, the payment will ...

### DIFF
--- a/templates/checkout/review_order.php
+++ b/templates/checkout/review_order.php
@@ -144,7 +144,11 @@
 				$available_gateways = jigoshop_payment_gateways::get_available_payment_gateways();
 				if ($available_gateways) : 
 					// Chosen Method
-					if (sizeof($available_gateways)) current($available_gateways)->set_current();
+					if (sizeof($available_gateways)) {
+						if( isset( $_POST['payment_method'] ) && isset( $available_gateways [ $_POST['payment_method'] ] ) )
+							$available_gateways [ $_POST['payment_method'] ]->set_current();
+						current($available_gateways)->set_current();	
+					}
 					foreach ($available_gateways as $gateway ) :
 						?>
 						<li>


### PR DESCRIPTION
Hí, I fixed a bug, when no JavaScript is available, and  there are errors in the checkout process, the payment will be reset to the first available payment method. 
This is critical for my german second payment page, which posts all variables back to the original checkout page. 

current($available_gateways)->set_current();
directly after 
$available_gateways = jigoshop_payment_gateways::get_available_payment_gateways();
will always point to the first element.
