### PR TITLE
Added classes to attributes and their values

### DIFF
--- a/classes/jigoshop_product.class.php
+++ b/classes/jigoshop_product.class.php
@@ -1101,7 +1101,7 @@ class jigoshop_product {
 				$terms = array();
 
 				foreach( $product_terms as $term ) {
-					$terms[] = $term->name;
+					$terms[] = '<span class="val_'.$term->slug.'">'.$term->name.'</span>';
 				}
 
 				$value = implode(', ', $terms);
@@ -1112,7 +1112,7 @@ class jigoshop_product {
 
 			// Generate the remaining html
 			$html .= "
-			<tr>
+			<tr class=\"attr_".$attr['name']."\">
 				<th>$name</th>
 				<td>$value</td>
 			</tr>";


### PR DESCRIPTION
My customer needed the possibility to display images instead of attributes names. He wanted to do it by css stylesheet, but the current attributes generator of HTML did not allow that in simple way. I changed the generated HTML from
tr -> th - td 
to
tr.attr_name -> th - td > span.val_slug
and that resolved the issue.

Regards
