### PR TITLE
remove default jigoshop_tax_classes

### DIFF
--- a/admin/jigoshop-admin-settings-options.php
+++ b/admin/jigoshop-admin-settings-options.php
@@ -1041,7 +1041,7 @@ $jigoshop_options_settings = apply_filters('jigoshop_options_settings', array(
 		'id' 		=> 'jigoshop_tax_classes',
 		'css' 		=> 'width:100%; height: 75px;',
 		'type' 		=> 'textarea',
-		'std' 		=> "Reduced Rate\nZero Rate"
+		'std' 		=> sprintf( __( 'Reduced Rate%sZero Rate', 'jigoshop' ), PHP_EOL ),
 	),
 
 	array(

--- a/languages/jigoshop-de_DE.po
+++ b/languages/jigoshop-de_DE.po
@@ -3286,6 +3286,11 @@ msgid "List product and shipping tax classes here, e.g. Zero Tax, Reduced Rate."
 msgstr "Produkt- und Versand-Mehrwertsteuerklassen hier auflisten, z.B. Keine MwSt., ermäßigter Satz, usw."
 
 #@ jigoshop
+#: admin/jigoshop-admin-settings-options.php:1044
+msgid "Reduced Rate%sZero Rate"
+msgstr "Ermäßigter Satz%sKeine MwSt."
+
+#@ jigoshop
 #: admin/jigoshop-admin-settings-options.php:847
 msgid "Tax rates"
 msgstr "Mehrwertsteuersätze"


### PR DESCRIPTION
The defaults were not stored in database by default, not translated and always appear again after trying to remove them completely if not needed.
They are still suggested as defaults in the field description.
