### PR TITLE
jigoshop_customer::address_form should not echo the translated value

### DIFF
--- a/classes/jigoshop_customer.class.php
+++ b/classes/jigoshop_customer.class.php
@@ -219,9 +219,9 @@ class jigoshop_customer extends jigoshop_singleton {
 
 		$title = '<h3>';
 		if($load_address=='billing'):
-			$title .=_e('Billing Address', 'jigoshop');
+			$title .= __('Billing Address', 'jigoshop');
 		else:
-			$title .= _e('Shipping Address', 'jigoshop');
+			$title .= __('Shipping Address', 'jigoshop');
 		endif;
 		$title .='</h3>';
 		echo $title;


### PR DESCRIPTION
Echo caused the title to render outside the H3 being built in $title
