### PR TITLE
Commit to allow for positive and negative coupon amounts

### DIFF
--- a/classes/jigoshop_cart.class.php
+++ b/classes/jigoshop_cart.class.php
@@ -426,16 +426,38 @@ class jigoshop_cart extends Jigoshop_Singleton {
 				switch ( $coupon['type'] ) :
 
 					case 'fixed_cart' :
+						if ($coupon['amount'] < 0){
+						$invertcoupon=$coupon['amount']*(-1);
+						self::$discount_total += $invertcoupon;
+						break;
+						}
+						else {
 						self::$discount_total += $coupon['amount'];
 						break;
-
+						}
 					case 'percent' :
-						self::$discount_total += ( $total_to_use / 100 ) * $coupon['amount'];
+						if ($coupon['amount'] < 0){
+						$invertcoupon=$coupon['amount']*(-1);
+						self::$discount_total += ( $total_to_use / 100 ) * $invertcoupon;
 						break;
+						}
+						else {
+						self::$discount_total += ( $total_to_use / 100 ) *$coupon['amount'];
+						break;
+						}
+						
 
 					case 'fixed_product' :
 						if ( sizeof( $coupon['include_products'] ) == 0 )
+							if ($coupon['amount'] < 0)
+							{
+							$invertcoupon=$coupon['amount']*(-1);
+							self::$discount_total += ( $invertcoupon * sizeof( self::$cart_contents ) );
+							}
+							else {
 							self::$discount_total += ( $coupon['amount'] * sizeof( self::$cart_contents ) );
+							}
+							
 						break;
 
 				endswitch;


### PR DESCRIPTION
Fixes issue that if a negative percent or discount amount is entered on the new coupon form, it will make the cart subtract the intended value. With current system, if you add a coupon for cart discount of -2.00 it adds $2. With this commit, -2.00 would subtract $2 from cart.
