### PR TITLE
Fixes Spacing Issue

### DIFF
--- a/admin/browser.php
+++ b/admin/browser.php
@@ -359,7 +359,7 @@
 		$wordwrapped = chunk_split($towrapUA, 32, "\n $space");
 			return "Platform:                 {$this->getPlatform()} \n".
 				   "        Browser Name:             {$this->getBrowser()}  \n" .
-			       "	Browser Version:          {$this->getVersion()} \n" .
+			       "    Browser Version:          {$this->getVersion()} \n" .
 			       "	User Agent String:        $UAline1 \n                                  " .
 				   "$wordwrapped ";
 		}


### PR DESCRIPTION
Fixes a spacing issue where 4 excess spaces seem to appear on the debug page prior to the "Browser name" line 
