### PR TITLE
Added filter for item to make possible price adjustment

### DIFF
--- a/gateways/paypal.php
+++ b/gateways/paypal.php
@@ -316,7 +316,7 @@ class paypal extends jigoshop_payment_gateway {
 				$paypal_args['item_name_'.$item_loop] = $title;
 				$paypal_args['quantity_'.$item_loop] = $item['qty'];
 				// use product price since we want the base price if it's including tax or if it's not including tax
-				$paypal_args['amount_'.$item_loop] = number_format($_product->get_price(), 2); //Apparently, Paypal did not like "28.4525" as the amount. Changing that to "28.45" fixed the issue.
+				$paypal_args['amount_'.$item_loop] = number_format( apply_filters( 'jigoshop_paypal_adjust_item_price' ,$_product->get_price(), $item), 2); //Apparently, Paypal did not like "28.4525" as the amount. Changing that to "28.45" fixed the issue.
 			endif;
 		endforeach; endif;
 


### PR DESCRIPTION
Filter gives possibility to adjust product price when PayPal gateway creates item list. This filter is needed by plugins such as Product Addons to have possibility to add extra costs to item.
