### PR TITLE
Added 'select' type for checkout_form_field to add custom select support to Billing and Shipping checkout fields.

### DIFF
--- a/classes/jigoshop_checkout.class.php
+++ b/classes/jigoshop_checkout.class.php
@@ -274,6 +274,8 @@ class jigoshop_checkout extends Jigoshop_Singleton {
 			'required'   => false,
 			'class'      => array(),
 			'label_class'=> array(),
+			'options'    => array(),
+			'selected'   => '',
 			'rel'        => '',
 			'return'     => false
 		);
@@ -364,6 +366,20 @@ class jigoshop_checkout extends Jigoshop_Singleton {
 					<label for="' . esc_attr( $args['name'] ) . '" class="'.implode(' ', $args['label_class']).'">'.$args['label'].$required.'</label>
 					<textarea name="'.esc_attr($args['name']).'" class="input-text' . esc_attr( $input_required ) . '" id="'.esc_attr($args['name']).'" placeholder="'.$args['placeholder'].'" cols="5" rows="2">'. esc_textarea( $this->get_value( $args['name'] ) ).'</textarea>
 				</p>'.$after;
+
+			break;
+			case "select" :
+				$field = '<p class="form-row '.implode(' ', $args['class']).'">
+					<label for="' . esc_attr( $args['name'] ) . '" class="'.implode(' ', $args['label_class']).'">'.$args['label'].$required.'</label>
+					<select name="'.esc_attr($args['name']).'" id="'.esc_attr($args['name']).'" class="input-text" rel="'.esc_attr($args['rel']).'">';
+
+				foreach(esc_attr($args['options']) as $key=>$value) :
+					$field .= '<option value="'.esc_attr($key).'"';
+					if (esc_attr($args['selected'])==$key) $field .= 'selected="selected"';
+					$field .= '>'.__($value, 'jigoshop').'</option>';
+				endforeach;
+
+				$field .= '</select></p>'.$after;
 
 			break;
 			default :


### PR DESCRIPTION
Plugins can now add a "select" field using "jigoshop_billing_fields" and "jigoshop_shipping_fields"
