### PR TITLE
Added 'select' type for checkout_form_field to allow plugins to add custom select fields to Billing and Shipping address.

### DIFF
--- a/classes/jigoshop_checkout.class.php
+++ b/classes/jigoshop_checkout.class.php
@@ -373,7 +373,7 @@ class jigoshop_checkout extends Jigoshop_Singleton {
 					<label for="' . esc_attr( $args['name'] ) . '" class="'.implode(' ', $args['label_class']).'">'.$args['label'].$required.'</label>
 					<select name="'.esc_attr($args['name']).'" id="'.esc_attr($args['name']).'" class="input-text" rel="'.esc_attr($args['rel']).'">';
 
-				foreach(esc_attr($args['options']) as $key=>$value) :
+				foreach($args['options'] as $key=>$value) :
 					$field .= '<option value="'.esc_attr($key).'"';
 					if (esc_attr($args['selected'])==$key) $field .= 'selected="selected"';
 					$field .= '>'.__($value, 'jigoshop').'</option>';


### PR DESCRIPTION
Using 'jigoshop_billing_fields' filter, jigoshop sends an array with the fields that get printed. Now, you can add a select field like such:

``` php
$fields[] = Array (
    'name'  => 'billing-town',
    'type'      => 'select', //NEW 'type'
    'label'     => 'Town',
    'required'  => 1,
    'class' => Array ('form-row-first'),
    'rel'       => 'my-rel',
    'options'   => Array ('PTA' => 'Pretoria', 'JHB' => 'Johannesburg', 'CPT' => 'Cape Town', ............), //NEW Field
    'selected'  => 'JHB' //NEW Field
);
```

and it should output:

``` html
<p class="form-row form-row-first">
    <label class="" for="billing-town">
        Town
        <span class="required">*</span>
    </label>
    <select id="billing-town" class="input-text" rel="my-rel" name="billing-town">
        <option value="PTA">Pretoria</option>
        <option selected="selected" value="JHB">Johannesburg</option>
        <option value="CPT">Cape Town</option>
    </select>
</p>
```
