### PR TITLE
Adds Jigoshop Version number to header

### DIFF
--- a/jigoshop.php
+++ b/jigoshop.php
@@ -919,8 +919,10 @@ function jigoshop_sanitize_user($username, $raw_username, $strict) {
 }
 
 add_action( 'wp_head', 'jigoshop_head_version' );
+if( ! function_exists('jigoshop_head_version') ) {
 function jigoshop_head_version() {
-echo "\n\n" . '<!-- Jigoshop Version:'.JIGOSHOP_HEAD_VERSION.' -->' . "\n\n";
+echo "\n" . '<!-- Jigoshop Version: '.JIGOSHOP_HEAD_VERSION.' -->' . "\n";
+}
 }
 
 


### PR DESCRIPTION
Seriously tired of people reporting incorrect version, or "I can't find it" or whatever. This pull introduces a pluggable function that puts a comment in the <head> so when I go to a site I can tell the Jigo version instantly.
