### PR TITLE
Added $paged to jigoshop_sale_products shortcode

### DIFF
--- a/shortcodes/init.php
+++ b/shortcodes/init.php
@@ -388,6 +388,7 @@ function jigoshop_sale_products( $atts ) {
 		'posts_per_page'            => $per_page,
 		'orderby'                   => $orderby,
 		'order'                     => $order,
+		'paged'                     => $paged,
 		'meta_query'                => array(
 				array(
 						'key'       => 'visibility',


### PR DESCRIPTION
The shortcode jigoshop_sale_products has an option for pagination, but the query doesn't include the $paged variable.
