### PR TITLE
Fix for product variable items toggling closed

### DIFF
--- a/assets/js/variable.js
+++ b/assets/js/variable.js
@@ -25,8 +25,8 @@
 
 		.on('click', '.postbox h3', function(e) {
 
-			//console.log( e.target.tagName.toLowerCase() );
-			if ( e.target.tagName.toLowerCase() === 'select' )
+			// the jquery event can still be triggered by other child elements, so we need to be explicit
+			if ( e.target.tagName.toLowerCase() != 'h3' && !$(this).hasClass('handlediv'))
 				return false;
 
 			$(this).parent().toggleClass('closed');


### PR DESCRIPTION
Changing attribute selectors in product data variable item headers causes the variation data to close due to the click event being triggered by the option elements too.
