### PR TITLE
Removed cellspacing=0 from two tables

### DIFF
--- a/classes/jigoshop_product.class.php
+++ b/classes/jigoshop_product.class.php
@@ -1175,7 +1175,7 @@ class jigoshop_product extends Jigoshop_Base {
 			return false;
 
 		// Start the html output
-		$html = '<table cellspacing="0" class="shop_attributes">';
+		$html = '<table class="shop_attributes">';
 
 		// Output weight if we have it
 		if (self::get_options()->get_option('jigoshop_enable_weight')=='yes' && $this->get_weight() ) {

--- a/jigoshop_template_functions.php
+++ b/jigoshop_template_functions.php
@@ -343,7 +343,7 @@ if (!function_exists('jigoshop_grouped_add_to_cart')) {
 		if(!$_product->get_children()) return;
 		?>
 		<form action="<?php echo esc_url( $_product->add_to_cart_url() ); ?>" class="cart" method="post">
-			<table cellspacing="0">
+			<table>
 				<tbody>
 					<?php foreach ($_product->get_children() as $child_ID) : $child = $_product->get_child($child_ID); $cavailability = $child->get_availability(); ?>
 						<tr>


### PR DESCRIPTION
Marcin from OptArt during implementation of datacentershop found few w3c validation incompatibilities in jigo core. Two of them are attached in this pull request.
