### PR TITLE
Contributing.md mention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ https://github.com/jigoshop/jigoshop/issues
 
 Contributing
 ------------
+See CONTRIBUTING.md
+------------
 
 Anyone and everyone is welcome to contribute. Jigoshop wouldn't be what it is today without the github community.
 


### PR DESCRIPTION
This is mostly so that we have a build on travis after we fixed that
subdependency. Because the hook was off at the time of pull, our image
on readme will be failed, because a build with the dependency back in
was never tested.  Recommend turning the hook on (and leaving it there),
and then merging this in.
