### PR TITLE
Adding actions required for shipping details.

### DIFF
--- a/shortcodes/my_account.php
+++ b/shortcodes/my_account.php
@@ -387,7 +387,11 @@ function jigoshop_view_order() {
             echo sprintf(__('Order status: <mark class="%s">%s</mark>', 'jigoshop'), sanitize_title($order->status), __($order->status, 'jigoshop') );
 
             echo '.</p>';
-            ?>
+           	
+			do_action( 'jigoshop_tracking_details_info', $order );
+			
+			?>
+			<h2><?php _e('Order Details', 'jigoshop'); ?></h2>
             <table class="shop_table">
                 <thead>
                     <tr>

--- a/shortcodes/order_tracking.php
+++ b/shortcodes/order_tracking.php
@@ -51,6 +51,8 @@ function jigoshop_order_tracking( $atts ) {
 				}
 				echo '.</p>';
 
+				do_action( 'jigoshop_tracking_details_info', $order );
+				
 				?>
 				<h2><?php _e('Order Details', 'jigoshop'); ?></h2>
 				<table class="shop_table">


### PR DESCRIPTION
Have added the actions required so that they can be called from within
the shipping details plugin to display the tracking info. Which without
these actions requires editing the files every time there is a jigoshop
update.
