### PR TITLE
Update to sale shortcode for sales between dates 

### DIFF
--- a/shortcodes/init.php
+++ b/shortcodes/init.php
@@ -371,8 +371,8 @@ function jigoshop_sale_products( $atts ) {
 		'pagination'                => false
 	), $atts));
 
-  	$today = date('Y-m-d',time());
-  	$tomorrow = date('Y-m-d',mktime(0, 0, 0, date("m"), date("d")+1, date("Y")) );
+  	$today = strotime(date('Y-m-d',time()));
+  	$tomorrow = strtotime(date('Y-m-d',mktime(0, 0, 0, date("m"), date("d")+1, date("Y")) ));
 
 	$args = array(
 		'post_type'                 => array( 'product' ),
@@ -401,7 +401,7 @@ function jigoshop_sale_products( $atts ) {
 				array(
 						'key'       => 'sale_price_dates_to',
 						'value'     => $tomorrow,
-						'compare'   => '<=',
+						'compare'   => '>=',
 				),
 		)
 	);


### PR DESCRIPTION
Unless I've completely misunderstood, the [sale_products] shortcode was broken for sales between dates. 

The 'sale_price_dates_from' and 'sale_price_dates_to' are saved as timestamps in the database, but compared with a regular date, plus the compare operator was wrong for 'sale_price_dates_to'.

I noticed the problem on a site I run, where the [sale_products] would keep showing products after the sale was over, but with the original price. This is how I changed the code there, and it seems to work fine.
