### PR TITLE
Order items dont need to times the cost by the quantity

### DIFF
--- a/classes/jigoshop_checkout.class.php
+++ b/classes/jigoshop_checkout.class.php
@@ -799,7 +799,7 @@ class jigoshop_checkout extends Jigoshop_Singleton {
                             'customization' => $custom,
 					 		'name' 			=> $_product->get_title(),
 					 		'qty' 			=> (int) $values['quantity'],
-					 		'cost'          => $_product->get_price_excluding_tax() * (int) $values['quantity'],
+					 		'cost'          => $_product->get_price_excluding_tax(),
                             'cost_inc_tax'  => $price_inc_tax, // if less than 0 don't use this
 					 		'taxrate' 		=> $rate
 					 	), $values);


### PR DESCRIPTION
To replicate this issue:
New install of jigoshop
Create a product
Go through the checkout with more than one of that product
Go to that order in the admin area

You will see that the quantity field is set correctly but the cost should only need to be the price of the product. Not the price x quantity.

This should also fix the issue when you click on the calculate totals button. 
