### PR TITLE
Remove download in confirmation emails for virtual products

### DIFF
--- a/classes/jigoshop_order.class.php
+++ b/classes/jigoshop_order.class.php
@@ -367,7 +367,7 @@ class jigoshop_order extends Jigoshop_Base {
 
 				if ($_product->exists) :
 
-					if ( ($_product->is_type('downloadable') || $_product->is_type('virtual')) ) :
+					if ( ( $_product->is_type('downloadable') ) ) :
 
 					if ( (bool) $item['variation_id'] ) {
 						$product_id = $_product->variation_id;


### PR DESCRIPTION
When purchasing a virtual products there is a download link included in the purchase confirmation email. Here is an example (with any personal info blurred)

![email](https://f.cloud.github.com/assets/254978/287712/6617a04e-925e-11e2-94d7-7fd5c68954a3.jpg)

When the download link is clicked, an error page is displayed

![error](https://f.cloud.github.com/assets/254978/287730/b749804a-925e-11e2-9ee7-0349bd8ad04c.jpg)

I presume this is not the intended behaviour for virtual products. Virtual products should be for products like services, intangibles etc. There is already a downloadable product type. 

I have created this pull request which amends the `classes/jigoshop_order.class.php` file at line `370` to remove an `||` comparison to include virtual product types. Without this, every virtual product confirmation email includes the non-existant download link, which is confusing for customers.

This is my first pull request here, if I have done anything incorrect please let me know. Many thanks.
