### PR TITLE
Use false instead of null when saving product

### DIFF
--- a/admin/write-panels/product-data-save.php
+++ b/admin/write-panels/product-data-save.php
@@ -230,14 +230,14 @@ class jigoshop_product_meta
 
 		// Create empty attributes array
 		$attributes = array();
-		
+
 		foreach( $attr_values as $key => $value ) {
 
 			// Skip if no value
 			if ( empty( $value )) continue;
-			
+
 			$has_tax = false;
-			
+
 			if ( ! is_array( $value ) && isset( $attr_variation[$key] ) && $attr_variation[$key] ) {
 			 	$value = explode( ',', $value );
 			 	$value = array_map( 'trim', $value );
@@ -251,13 +251,13 @@ class jigoshop_product_meta
 				wp_set_object_terms( $post_id, $value, 'pa_'.sanitize_title($attr_names[$key]) );
 				$has_tax = true;
 			}
-			
+
 			$attributes[ sanitize_title($attr_names[$key]) ] = array(
 				'name'        => $attr_names[$key],
 				'value'       => $value,
 				'position'    => $attr_position[$key],
 				'visible'     => isset( $attr_visibility[$key] ),
-				'variation'   => isset( $attr_variation[$key] ) ? $attr_variation[$key] : null,
+				'variation'   => isset( $attr_variation[$key] ) ? $attr_variation[$key] : false,
 				'is_taxonomy' => $has_tax
 			);
 		}


### PR DESCRIPTION
Using null causes [Product CSV Suite](http://shop.mgates.me/shop/jigoshop/product-csv-suite/) to not export attributes. 
