### PR TITLE
Jigoshop update hid some "Add to cart" buttons

### DIFF
--- a/jigoshop_template_functions.php
+++ b/jigoshop_template_functions.php
@@ -119,7 +119,7 @@ if (!function_exists('jigoshop_template_loop_add_to_cart')) {
 				} else {
 					$output = '';
 				}
-			} else if ( $button_type == 'add' ) {
+			} else if ( $button_type == 'add' || $button_type == 'cart' ) {
 				$output = '<a href="'.esc_url($_product->add_to_cart_url()).'" class="button" rel="nofollow">'.__('Add to cart', 'jigoshop').'</a>';
 			} else if ( $button_type == 'view' ) {
 				$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';


### PR DESCRIPTION
Basically the $button_type was set to 'cart' for some reason, possibly an older version of Jigoshop set this value.

A $button_type of 'cart' will ouput NO button. This caused a lot of angry users of my theme. Here is a fix.

More details in this forum thread:

http://forum.jigoshop.com/discussions/problems/9870-add-to-cart-buttons-have-disappeared
