### PR TITLE
Adds e-mail payment confirmation to Skrill

### DIFF
--- a/gateways/skrill.php
+++ b/gateways/skrill.php
@@ -230,7 +230,9 @@ class skrill extends jigoshop_payment_gateway {
 			'detail1_description'  => 'Order ID',
 			'detail1_text'         => $order_id,
 
-			'payment_methods'				=> $this->payment_methods
+			'payment_methods'				=> $this->payment_methods,
+			
+			'status_url2'						=> 'mailto:'.$this->email
 		);
 
 		// Cart Contents


### PR DESCRIPTION
To receive e-mails from Skrill when an order is placed you need to
provide Skrill with an e-mail address on every order.
