### PR TITLE
Change to $setting instead of $option variable

### DIFF
--- a/admin/jigoshop-admin-settings-api.php
+++ b/admin/jigoshop-admin-settings-api.php
@@ -383,7 +383,8 @@ class Jigoshop_Admin_Settings extends Jigoshop_Singleton {
 				// $value has the WordPress user submitted value for this $setting
 				// $option has this $setting parameters
 				// validate for $option 'type' checking for a submitted $value
-				switch ( $option['type'] ) {
+
+				switch ( $setting['type'] ) {
 				case 'user_defined' :
 					if ( isset( $option['update'] ) ) {
 						if ( is_callable( $option['update'], true ) ) {


### PR DESCRIPTION
This will create an erroneous loop in $defaults if you set multiple equal to true in dropdown option type.
