### PR TITLE
Method to set shipping error

### DIFF
--- a/classes/jigoshop_shipping.class.php
+++ b/classes/jigoshop_shipping.class.php
@@ -102,6 +102,10 @@ class jigoshop_shipping extends Jigoshop_Singleton {
         return apply_filters('jigoshop_available_shipping_methods',$_available_methods);
     }
 
+    public static function set_shipping_error_message($message) {
+        self::$shipping_error_message = $message;
+    }
+
     public static function get_shipping_error_message() {
     	return self::$shipping_error_message;
     }


### PR DESCRIPTION
Small change to allow custom shipping plugins to set a custom error message on the review order page.
