### PR TITLE
Added enctype=multipart/form-data to admin settings forms

### DIFF
--- a/admin/jigoshop-admin-settings-api.php
+++ b/admin/jigoshop-admin-settings-api.php
@@ -217,7 +217,7 @@ class Jigoshop_Admin_Settings extends Jigoshop_Singleton {
 
 				<?php settings_errors(); ?>
 
-				<form action="options.php" id="mainform" method="post">
+				<form action="options.php" id="mainform" method="post" enctype="multipart/form-data">
 
 					<div class="jigoshop-settings">
 						<div id="tabs-wrap">


### PR DESCRIPTION
For use with user defined file type input fields. 
Sample usage case: need to upload key and certificate files for a payment gateway.
