### PR TITLE
Some images get stretched by 150x150 on shop page

### DIFF
--- a/assets/css/frontend.less
+++ b/assets/css/frontend.less
@@ -384,10 +384,10 @@ span.onsale {
 			text-decoration: none;
 		}
 		a img {
-			width: 150px !important;
-			height: 150px !important;
+			max-width: 150px !important;
+			max-height: 150px !important;
 			display: block;
-			margin: 0 0 8px !important;
+			margin: 0 auto 8px !important;
 			border: 1px solid #ddd;
 		}
 		a:hover img {


### PR DESCRIPTION
Changed width and height to max-width and max-height for .products li a img, and set margin to 0 auto 8px to center it.  I think it achieves nearly the same result, but avoids stretching photos.
