### PR TITLE
Proposed change for issue #945

### DIFF
--- a/gateways/paypal.php
+++ b/gateways/paypal.php
@@ -27,6 +27,7 @@ add_filter('jigoshop_payment_gateways', function ($methods){
 
 class paypal extends jigoshop_payment_gateway {
 
+	// based on PayPal currency rule: https://developer.paypal.com/docs/classic/api/currency_codes/
 	private static $no_decimal_currencies = array('HUF', 'JPY', 'TWD');
 
 	public function __construct(){


### PR DESCRIPTION
This could be a fix for PayPal error _"The link you have used to enter the PayPal system contains an incorrectly formatted item amount."_ for certain currencies.

Based on PayPal's [Multicurrency support for PayPal payments](https://developer.paypal.com/docs/classic/api/currency_codes/).
