### PR TITLE
Validation fix

### DIFF
--- a/gateways/paypal.php
+++ b/gateways/paypal.php
@@ -521,7 +521,7 @@ class paypal extends jigoshop_payment_gateway {
 						}
 
 						// Validate Amount
-						if(number_format((float)$order->order_total, $this->decimals) != $posted['mc_gross']){
+						if(number_format((float)$order->order_total, $this->decimals, '.', '') != $posted['mc_gross']){
 							// Put this order on-hold for manual checking
 							$order->update_status('on-hold', sprintf(__('PayPal Validation Error: Payment amounts do not match initial order (gross %s).', 'jigoshop'), $posted['mc_gross']));
 							exit;


### PR DESCRIPTION
Sorry, my bad. Not proper testing, I know...
Though PayPal doesn't seem to be sensitive to thousand separators it returns this value _without_ it, so to make the two strings equal our part should not have separator either.
