### PR TITLE
Return false on gateway process_payment failure.

### DIFF
--- a/classes/jigoshop_checkout.class.php
+++ b/classes/jigoshop_checkout.class.php
@@ -1075,6 +1075,8 @@ class jigoshop_checkout extends Jigoshop_Singleton {
 					if ($result['result'] == 'success') {
 						return $result;
 					}
+					
+					return false;
 				} else {
 					// No payment was required for order
 					$order->payment_complete();


### PR DESCRIPTION
Return false, when gateway process_payment is not successful. Otherwise the customer is redirected to an undefined page.
