### PR TITLE
Added params to user defined settings fields

### DIFF
--- a/admin/jigoshop-admin-settings-api.php
+++ b/admin/jigoshop-admin-settings-api.php
@@ -357,7 +357,7 @@ class Jigoshop_Admin_Settings extends Jigoshop_Singleton {
 						case 'user_defined' :
 							if(isset($option['update'])){
 								if(is_callable($option['update'], true)){
-									if(isset($oprion['params'])){
+									if(isset($option['params'])){
 										$result = call_user_func_array($option['update'], $option['params']);
 									} else {
 										$result = call_user_func($option['update']);


### PR DESCRIPTION
It allows to create own function which will display all custom fields based on params from additional array, i.e.
array(
    'name' => 'Expiry Date,
    'id' => 'exp_date',
    'type' => 'user_defined',
    'display' => 'getUserDefinedFields',
    'params' => array('date', 'exp_date', 'rrrr-mm-dd') //
);

function getUserDefinedFields($option, $id, $placeholder){
    switch ($option){
        case 'date' : 
            return 'input type="text" id=".$id.'" name="'.id.'" class="date-pick" value="" placeholder="'.$placeholder.'" /';
        }
}
