### PR TITLE
Update jigoshop_template_functions.php

### DIFF
--- a/jigoshop_template_functions.php
+++ b/jigoshop_template_functions.php
@@ -105,45 +105,49 @@ if (!function_exists('jigoshop_template_loop_add_to_cart')) {
 		do_action('jigoshop_before_add_to_cart_button');
 
 		// do not show "add to cart" button if product's price isn't announced
-		if ( $_product->get_price() === '' AND ! ($_product->is_type(array('variable', 'grouped', 'external'))) ) return;
-
-		if ( $_product->is_in_stock() OR $_product->is_type('external') ) {
-			$button_type = Jigoshop_Base::get_options()->get('jigoshop_catalog_product_button');
-			if ( $button_type === false ) $button_type = 'add';
-			if ( $_product->is_type(array('variable', 'grouped')) ) {
-				if ( $button_type != 'none' ) {
-					if ( $button_type == 'view' ) {
-						$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';
-					} else {
-						$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'._x('Select', 'verb', 'jigoshop').'</a>';
-					}
-				} else {
-					$output = '';
-				}
-			} else if ( $_product->is_type('external') ) {
-				if ( $button_type != 'none' ) {
-					if ( $button_type == 'view' ) {
-						$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';
-					} else {
-						$output = '<a href="'.esc_url(get_post_meta( $_product->id, 'external_url', true )).'" class="button" rel="nofollow">'.__('Buy product', 'jigoshop').'</a>';
-					}
-				} else {
-					$output = '';
-				}
-			} else if ( $button_type == 'add' ) {
-				$output = '<a href="'.esc_url($_product->add_to_cart_url()).'" class="button" rel="nofollow">'.__('Add to cart', 'jigoshop').'</a>';
-			} else if ( $button_type == 'view' ) {
-				$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';
-			} else {
-				$output = '';
-			}
-		} else if ( ($_product->is_type(array('grouped')) ) ) {
-			$output = '';
+		if ( $_product->get_price() === '' AND ! ($_product->is_type(array('variable', 'grouped', 'external'))) ) {
+			// do nothing
 		} else {
-			$output = '<span class="nostock">'.__('Out of Stock', 'jigoshop').'</span>';
+			if ( $_product->is_in_stock() OR $_product->is_type('external') ) {
+				$button_type = Jigoshop_Base::get_options()->get('jigoshop_catalog_product_button');
+				if ( $button_type === false ) $button_type = 'add';
+				if ( $_product->is_type(array('variable', 'grouped')) ) {
+					if ( $button_type != 'none' ) {
+						if ( $button_type == 'view' ) {
+							$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';
+						} else {
+							$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'._x('Select', 'verb', 'jigoshop').'</a>';
+						}
+					} else {
+						$output = '';
+					}
+				} else if ( $_product->is_type('external') ) {
+					if ( $button_type != 'none' ) {
+						if ( $button_type == 'view' ) {
+							$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';
+						} else {
+							$output = '<a href="'.esc_url(get_post_meta( $_product->id, 'external_url', true )).'" class="button" rel="nofollow">'.__('Buy product', 'jigoshop').'</a>';
+						}
+					} else {
+						$output = '';
+					}
+				} else if ( $button_type == 'add' ) {
+					$output = '<a href="'.esc_url($_product->add_to_cart_url()).'" class="button" rel="nofollow">'.__('Add to cart', 'jigoshop').'</a>';
+				} else if ( $button_type == 'view' ) {
+					$output = '<a href="'.esc_url(get_permalink($_product->id)).'" class="button">'.__('View Product', 'jigoshop').'</a>';
+				} else {
+					$output = '';
+				}
+			} else if ( ($_product->is_type(array('grouped')) ) ) {
+				$output = '';
+			} else {
+				$output = '<span class="nostock">'.__('Out of Stock', 'jigoshop').'</span>';
+			}
+			
+			
+			echo apply_filters( 'jigoshop_loop_add_to_cart_output', $output, $post, $_product );
 		}
 
-		echo apply_filters( 'jigoshop_loop_add_to_cart_output', $output, $post, $_product );
 
 		do_action('jigoshop_after_add_to_cart_button');
 


### PR DESCRIPTION
In function jigoshop_template_loop_add_to_cart() ... 

The way it's written, the action 'jigoshop_after_add_to_cart_button' is not firing if the product doesn't have a price set; this is a problem for me (and could be for others) if we bind anything to 'jigoshop_before_add_to_cart_button' ... for example, I'm opening a div in the 'before' action and closing it in the 'after' action, and if there's no price on the product, the opening div is output but not the closing one, which breaks my layout.

So instead of just "return"-ing after checking if there's a price set, I put it in an if/else that just does nothing if it evaluates to true, so that it will continue and fire the 'after' action (as well as the 'apply_filters' ... but I wasn't 100% sure on that part)
