### PR TITLE
Shop slugs

### DIFF
--- a/jigoshop_taxonomy.php
+++ b/jigoshop_taxonomy.php
@@ -27,12 +27,12 @@ function jigoshop_post_type()
 	$category_base = ($options->get('jigoshop_prepend_shop_page_to_urls') == 'yes') ? trailingslashit($base_slug) : '';
 	$category_slug = ($options->get('jigoshop_product_category_slug')) ? $options->get('jigoshop_product_category_slug') : _x('product-category', 'slug', 'jigoshop');
 	$tag_slug = ($options->get('jigoshop_product_tag_slug')) ? $options->get('jigoshop_product_tag_slug') : _x('product-tag', 'slug', 'jigoshop');
-	$product_base .= ($options->get('jigoshop_product_slug')) ? $options->get('jigoshop_product_slug') : _x('product', 'slug', 'jigoshop');
-	if ($options->get('jigoshop_prepend_category_to_product') == 'yes') {
-		$product_base = '%product_cat%';
-	}
+	$product_base = ($options->get('jigoshop_product_slug')) ? $options->get('jigoshop_product_slug') : _x('product', 'slug', 'jigoshop');
 	if ($options->get('jigoshop_prepend_shop_page_to_product') == 'yes') {
 		$product_base = trailingslashit($base_slug) . $product_base;
+	}
+	if ($options->get('jigoshop_prepend_category_to_product') == 'yes') {
+		$product_base = $category_base . '%product_cat%';
 	}
 
 	register_post_type("product",


### PR DESCRIPTION
Hey lads,

Could you take a look at these changes?

Originally I wanted to change the code only to allow the "product" prefix to be modifiable through admin 
settings as all other prefixes. Why has this been left out? Could there be a setting for this as well so if I wanted to localize it I could do it at the same place as the others and not have that separately in a translation file?

As for the rest of the changes: I've found the original logic a little bit confusing. I couldn't really figure what were the use cases, so it might have been totally fine, but let me describe my changed logic:
- if one checks nothing for the product prefix it would be: `product`
- if one checks "Prepend product permalinks with shop base page" but not "Prepend product permalinks with product category" the prefix would be: `shop/product`
- if one checks "Prepend product permalinks with product category" it would not matter if the other option would be checked (it could even be greyed out in the settings page) and the prefix would be URL ending of the category. With the same rules as for the category. So either `shop/product-cat/my-category` or `product-cat/my-category`

Of course for this to work the `jigoshop_options.class.php` has to be modified (product prefix added, and optionally the greying-out effect).

So I'm not asking to merge these changes, I'm just interested in your opinion.

Cheers.
