### PR TITLE
respect bundled lightbox setting

### DIFF
--- a/jigoshop.php
+++ b/jigoshop.php
@@ -912,11 +912,14 @@ add_action('init', 'jigoshop_check_required_css', 99);
 function jigoshop_check_required_css()
 {
 	global $wp_styles;
+	$options = Jigoshop_Base::get_options();
 
 	if (empty($wp_styles->registered['jigoshop_styles'])) {
 		jrto_enqueue_style('frontend', 'jigoshop-jquery-ui', JIGOSHOP_URL.'/assets/css/jquery-ui.css');
 		jrto_enqueue_style('frontend', 'jigoshop-select2', JIGOSHOP_URL.'/assets/css/select2.css');
-		jrto_enqueue_style('frontend', 'prettyPhoto', JIGOSHOP_URL.'/assets/css/prettyPhoto.css');
+		if ($options->get('jigoshop_disable_fancybox') == 'no') {
+			jrto_enqueue_style('frontend', 'prettyPhoto', JIGOSHOP_URL.'/assets/css/prettyPhoto.css');
+		}
 	}
 }
 


### PR DESCRIPTION
Recently I've switched from the built-in lightbox to another one, and I noticed that `prettyPhoto.css` was still loading in the frontend though I had "Disable bundled Lightbox" turned on in the settings.

With this change it won't be loading.

However when the bundled thingie is not disabled it will be enqueued twice: first in `jigoshop_frontend_scripts()` and then here. Not that WodPress couldn't handle that, it just feels a little sloppy.

That made me wonder that what could have been the reason for having these 3 styles here in a separate method on the same init hook than `jigoshop_frontend_scripts()`? What was the logic not putting these 3 there?