### PR TITLE
hook for payment gateway plugins

### DIFF
--- a/gateways/gateways.class.php
+++ b/gateways/gateways.class.php
@@ -36,6 +36,8 @@ class jigoshop_payment_gateways extends Jigoshop_Singleton
 	 */
 	public static function gateways_init()
 	{
+		do_action('jigoshop_payment_gateways_init'); /* load plugins for gateway inits */
+
 		$load_gateways = apply_filters('jigoshop_payment_gateways', array());
 
 		foreach ($load_gateways as $gateway) {


### PR DESCRIPTION
Hey lads,

There is a convenient hook in `jigoshop/classes/jigoshop_shipping.class.php` for plugins to initiate their classes without checking for the existence of their superclass to extend.
It would be similarly useful to have it here.

So in the plugins instead of
```
add_action( 'plugins_loaded', function() {
  if ( !class_exists( 'jigoshop_payment_gateway' ) ) return;
  class jigoshop_custom_gateway extends jigoshop_payment_gateway {
```
it could be only
```
add_action( 'jigoshop_payment_gateways_init', function() {
  class jigoshop_custom_gateway extends jigoshop_payment_gateway {
```