### PR TITLE
email templating update

### DIFF
--- a/classes/jigoshop_emails.class.php
+++ b/classes/jigoshop_emails.class.php
@@ -88,7 +88,8 @@ class jigoshop_emails extends Jigoshop_Base
 					$title = str_replace('['.get_bloginfo('name').'] ', '', $post->post_title);
 
 					$template = file_get_contents($path);
-					$template = str_replace('{heading}', $title, $template);
+					$template = str_replace('{title}', $title, $template);
+					$template = str_replace('{heading}', apply_filters('jigoshop_email_heading', $title), $template);
 					$template = str_replace('{content}', $content, $template);
 					$template = str_replace('{footer}', apply_filters('jigoshop_email_footer', $footer), $template);
 				}

--- a/templates/emails/layout.html
+++ b/templates/emails/layout.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<title>{heading}</title>
+	<title>{title}</title>
 	<style type="text/css">
 		/* Client-specific Styles */
 		#outlook a {


### PR DESCRIPTION
Lads,

During the process to update to the most recent version - beside my other issue with the reports - I found this limitation in the new email templating:

I'm running Jigoshop on a networked WP install and while I can completely replace the `layout.html` in my theme I can't distinguish between my different sites to do slightly different things (basically putting in site-specific URLs) for the heading.

For the footer there's a hook I can use, but I would need a similar one for the heading block.

More to that: since I'm about to put non-basic stuff in the heading, the same string won't be good for having it in the HTML title. So I also suggest to separate the two while providing the same content by default.

What do you think?