### PR TITLE
saving custom order data hook

### DIFF
--- a/admin/write-panels/order-data-save.php
+++ b/admin/write-panels/order-data-save.php
@@ -179,6 +179,9 @@ function jigoshop_process_shop_order_meta($post_id)
 		}
 	}
 
+	// Process custom attributes added with "jigoshop_order_data_panels"
+	$data = apply_filters("jigoshop_order_data_save", $data, $post_id);
+
 	// Save
 	update_post_meta($post_id, 'order_data', $data);
 	update_post_meta($post_id, 'order_items', $order_items);


### PR DESCRIPTION
With this filter it would either be possible to put additional fields into the ''order_data'' array,
but it would also be possible to do any kind of additional saves (into other meta attributes).

Meant to be a fix for issue #1045