### PR TITLE
add product object as a parameter to the 'jigoshop_single_product_price' filter

### DIFF
--- a/jigoshop_template_functions.php
+++ b/jigoshop_template_functions.php
@@ -368,7 +368,7 @@ if (!function_exists('jigoshop_template_single_title')) {
 if (!function_exists('jigoshop_template_single_price')) {
 	function jigoshop_template_single_price($post, $_product)
 	{
-		?><p class="price"><?php echo apply_filters('jigoshop_single_product_price', $_product->get_price_html()); ?></p><?php
+		?><p class="price"><?php echo apply_filters('jigoshop_single_product_price', $_product->get_price_html(), $_product); ?></p><?php
 	}
 }
 

--- a/jigoshop_template_functions.php
+++ b/jigoshop_template_functions.php
@@ -361,7 +361,7 @@ if (!function_exists('jigoshop_output_product_data_tabs')) {
 if (!function_exists('jigoshop_template_single_title')) {
 	function jigoshop_template_single_title($post, $_product)
 	{
-		?><h1 class="product_title page-title"><?php echo apply_filters('jigoshop_single_product_title', the_title('', '', false)); ?></h1><?php
+		?><h1 class="product_title page-title"><?php echo apply_filters('jigoshop_single_product_title', the_title('', '', false), $_product); ?></h1><?php
 	}
 }
 


### PR DESCRIPTION
Hey lads,

I'm trying to add [product markup](http://schema.org/Product) to the product pages but Google doesn't like the formatted price value that I have here. I'll need to add separate tags for the numerical value and the currency but I can't do it without having the product object as a parameter in the filter.

Would you accept this change?

P.S: I know I could be adding this markup at (maybe many) completely different places as well, where I would have the product object, but this it The Place of outputting the price so it just feels right to put the price markup here.