### PR TITLE
hook for additional Analytics settings

### DIFF
--- a/jigoshop_actions.php
+++ b/jigoshop_actions.php
@@ -797,6 +797,7 @@ function jigoshop_ga_tracking()
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 		})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'jigoshopGA');
 		jigoshopGA('create', '<?php echo $tracking_id; ?>', { 'userId': '<?php echo $user_id; ?>' });
+		<?php do_action('jigoshop_ga_tracking'); ?>
 		jigoshopGA('send', 'pageview');
 	</script>
 <?php


### PR DESCRIPTION
I'd like to extend my shop with dynamic retargeting data, and doing it through Analytics seems to be a better option than AdWords tagging (because of adblockers).

For that I need to set extra attibutes between the "create" and "send" and either this change or I have to remove and copy the whole function.

I figured this 1-liner is nicer. Please add it to the next release.

Thanks a million