### PR TITLE
Fix for "undefined index" warning

### DIFF
--- a/classes/jigoshop.class.php
+++ b/classes/jigoshop.class.php
@@ -248,7 +248,7 @@ class jigoshop extends Jigoshop_Singleton
 		$action = 'jigoshop-'.$action;
 		$request = array_merge($_GET, $_POST);
 
-		if (!wp_verify_nonce($request[$name], $action)) {
+		if (!isset($request[$name]) || !iwp_verify_nonce($request[$name], $action)) {
 			jigoshop::add_error(__('Action failed. Please refresh the page and retry.', 'jigoshop'));
 
 			return false;


### PR DESCRIPTION
I'm getting `PHP Notice:  Undefined index: _n in .../wp-content/plugins/jigoshop/classes/jigoshop.class.php on line 251` quite regularly.
I'm not sure where it is called from, but this could fix it.
